### PR TITLE
Email otp

### DIFF
--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -829,6 +829,26 @@ class CognitoUser {
     return true;
   }
 
+  /// TODO: Merge with `confirmRegistration` if possible
+  Future<String?> confirmRegistrationWithEmailOtp(
+    String confirmationCode,
+  ) async {
+    final params = {
+      'ClientId': pool.getClientId(),
+      'ConfirmationCode': confirmationCode,
+      'Username': username,
+    };
+
+    final data = await client!.request(
+        'ConfirmSignUp', await _analyticsMetadataParamsDecorator.call(params));
+
+    try {
+      return data['Session'];
+    } catch (e) {
+      return null;
+    }
+  }
+
   /// This is used by a user to resend a confirmation code
   dynamic resendConfirmationCode() async {
     final params = {

--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -526,7 +526,7 @@ class CognitoUser {
 
   /// This is used for authenticating the user through the user authentication flow.
   /// return: Session string
-  Future<String?> signInWithEmailOtp() async {
+  Future<String> signInWithEmailOtp() async {
     final paramsReq = {
       'AuthFlow': 'USER_AUTH',
       'ClientId': pool.getClientId(),

--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -524,6 +524,24 @@ class CognitoUser {
     return _signInUserSession;
   }
 
+  /// This is used for authenticating the user through the user authentication flow.
+  /// return: Session string
+  Future<String?> signInWithEmailOtp() async {
+    final paramsReq = {
+      'AuthFlow': 'USER_AUTH',
+      'ClientId': pool.getClientId(),
+      'AuthParameters': {
+        'USERNAME': username,
+        'PREFERRED_CHALLENGE': 'EMAIL_OTP',
+      },
+    };
+
+    final data = await client!.request('InitiateAuth',
+        await _analyticsMetadataParamsDecorator.call(paramsReq));
+
+    return data['Session'];
+  }
+
   /// This is used for authenticating the user.
   Future<CognitoUserSession?> authenticateUser(
       AuthenticationDetails authDetails) async {
@@ -826,6 +844,47 @@ class CognitoUser {
         await _analyticsMetadataParamsDecorator.call(params));
 
     return data;
+  }
+
+  /// This is used by the user once he has the responses to a email otp challenge
+  Future<CognitoUserSession?> sendEmailOtpChallengeAnswer(
+    String answerChallenge,
+    String session, [
+    Map<String, String>? validationData,
+  ]) async {
+    final challengeResponses = {
+      'USERNAME': username,
+      'EMAIL_OTP_CODE': answerChallenge,
+    };
+
+    final authenticationHelper =
+        AuthenticationHelper(pool.getUserPoolId().split('_')[1]);
+
+    await getCachedDeviceKeyAndPassword();
+    if (_deviceKey != null) {
+      challengeResponses['DEVICE_KEY'] = _deviceKey;
+    }
+
+    if (_clientSecretHash != null) {
+      challengeResponses['SECRET_HASH'] = _clientSecretHash;
+    }
+
+    final paramsReq = {
+      'ChallengeName': 'EMAIL_OTP',
+      'ChallengeResponses': challengeResponses,
+      'ClientId': pool.getClientId(),
+      'ClientMetadata': validationData,
+      'Session': session,
+    };
+
+    if (getUserContextData() != null) {
+      paramsReq['UserContextData'] = getUserContextData();
+    }
+
+    final data = await client!.request('RespondToAuthChallenge',
+        await _analyticsMetadataParamsDecorator.call(paramsReq));
+
+    return _authenticateUserInternal(data, authenticationHelper);
   }
 
   /// This is used by the user once he has the responses to a custom challenge

--- a/lib/src/cognito_user.dart
+++ b/lib/src/cognito_user.dart
@@ -554,6 +554,28 @@ class CognitoUser {
     throw UnimplementedError('Authentication flow type is not supported.');
   }
 
+  /// This is used for authenticating the user with email otp.
+  Future<CognitoUserSession?> authenticateUserWithEmailOtp(
+    String session,
+  ) async {
+    final params = {
+      'AuthFlow': 'USER_AUTH',
+      'ClientId': pool.getClientId(),
+      'AuthParameters': {
+        'USERNAME': username,
+        'PREFERRED_CHALLENGE': 'EMAIL_OTP',
+      },
+      'Session': session,
+    };
+
+    final data = await client!.request('InitiateAuth', params);
+
+    final authenticationHelper =
+        AuthenticationHelper(pool.getUserPoolId().split('_')[1]);
+
+    return _authenticateUserInternal(data, authenticationHelper);
+  }
+
   /// This is used for the user to signOut of the application and clear the cached tokens.
   /// If `revokeRefreshToken` is set to true, it will revoke the refresh token.
   Future<void> signOut({bool revokeRefreshToken = false}) async {

--- a/lib/src/cognito_user_pool.dart
+++ b/lib/src/cognito_user_pool.dart
@@ -107,8 +107,8 @@ class CognitoUserPool {
   /// user name, password, optional user attributes, optional validation data
   /// and optional client metadata.
   Future<CognitoUserPoolData> signUp(
-    String username,
-    String password, {
+    String username, {
+    String? password,
     List<AttributeArg>? userAttributes,
     List<AttributeArg>? validationData,
     Map<String, String>? clientMetadata,


### PR DESCRIPTION
This pull request includes several changes to the `lib/src/cognito_user.dart` and `lib/src/cognito_user_pool.dart` files to add support for email OTP authentication flow and to modify the `signUp` method. The most important changes include the addition of methods for signing in with email OTP and handling email OTP challenges, as well as making the password parameter optional in the `signUp` method.

Enhancements to email OTP authentication:

* [`lib/src/cognito_user.dart`](diffhunk://#diff-4e2e691bcb4630618de7409fdcd6f0538e53fcf80569f0d72f99e5ca4c49ca23R527-R544): Added the `signInWithEmailOtp` method for initiating the email OTP authentication flow.
* [`lib/src/cognito_user.dart`](diffhunk://#diff-4e2e691bcb4630618de7409fdcd6f0538e53fcf80569f0d72f99e5ca4c49ca23R849-R889): Added the `sendEmailOtpChallengeAnswer` method for handling the response to an email OTP challenge.

Modification to user pool sign-up:

* [`lib/src/cognito_user_pool.dart`](diffhunk://#diff-ae0714797f1a4cf6e48e3af1a68f1e5600a986e6a878acb2a8f28d04d25a3953L110-R111): Modified the `signUp` method to make the `password` parameter optional.